### PR TITLE
add contribution guidelines wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@ This is a Grow with Google project for an offline first app that provides inform
 ## Working Demo
 https://script.google.com/macros/s/AKfycbyeAP8n-wwIYmGGqStDIRcxnVa8QtA-RDKpgsiPCudzWVA7VByd/exec
 
-## To Get Started
+## Getting Started
 Read the the [Set Up Instructions](https://github.com/gwg-women/gwg-women-techmakers/wiki/Set-Up-Instructions) on our wiki.
+
+## Contributing to the Project
+Please read the [contribution guidelines](https://github.com/gwg-women/gwg-women-techmakers/wiki/Contribution-Guidelines) on the wiki to see how to get started with solving issues and creating pull requests.
 
 ## Pending
 - Whether we use geolocation or use the search box instead


### PR DESCRIPTION
Closes #27 

- Created a contributions guidelines page on the wiki
- Add link to the README page

QA:
- [ ] Check that Contributions Guidelines wiki link works
- [ ] View new [wiki page](https://github.com/gwg-women/gwg-women-techmakers/wiki/Contribution-Guidelines)

Note: additional updates welcome on the Contributions page. I just wanted to get something up now to help people along as they start picking issues and pushing their changes.