### PR TITLE
Fix geolocation.getCurrentPosition() timing out

### DIFF
--- a/src/components/Header.js.orig
+++ b/src/components/Header.js.orig
@@ -13,24 +13,23 @@ export default class HeaderContainer extends Component {
       console.log('Error retrieving the current city: ', err);
     });
 
+<<<<<<< HEAD
+  getMyLocation = () => {
+    const {handleLocationChange} = this.props;
+    const currentLocation = (position) =>{
+  
+=======
     getWeather(latitude, longitude).then((weather) => {
       this.setState({currentWeather: weather})
     }).catch(function(err){
       console.log('Error retrieving the current weather: ', err);
     })
   }
-
+    
   getMyLocation = () => {    
-    const {handleLocationChange} = this.props;
     const cachedLatitude = localStorage.getItem('lat');
     const cachedLongitude = localStorage.getItem('lng');    
 
-    const pos = {
-        lat: cachedLatitude,
-        lng: cachedLongitude
-      }
-      
-    handleLocationChange(pos);
     if (cachedLatitude && cachedLongitude) {
        this.getCityWeather(cachedLatitude, cachedLongitude);     
     }    
@@ -41,15 +40,31 @@ export default class HeaderContainer extends Component {
 
     const currentLocation = (position) => {
       console.log('current position is updated');
+>>>>>>> Fix geolocation.getCurrentPosition() timing out
       const pos = {
         lat: position.coords.latitude,
         lng: position.coords.longitude
       }
+<<<<<<< HEAD
       handleLocationChange(pos);
+
+      getCity(pos.lat, pos.lng).then((city) => {
+        this.setState({currentCity: city})
+      }).catch(function(err) {
+        console.log('Error retrieving the current city: ', err);
+      });
+  
+      getWeather(pos.lat, pos.lng).then((weather) => {
+        this.setState({currentWeather: weather})
+      }).catch(function(err){
+        console.log('Error retrieving the current weather: ', err);
+      })  
+=======
 
       localStorage.setItem('lat', pos.lat);
       localStorage.setItem('lng', pos.lng); 
       this.getCityWeather(pos.lat, pos.lng);
+>>>>>>> Fix geolocation.getCurrentPosition() timing out
     }
   
     // Ask user for permission to use location services


### PR DESCRIPTION
The reason why city info is not showed after refreshing is because .getCurrentPosition is timing out. This commit include:
1. cache current position into local storage if currentPosition is returned
2. restore location using cache if available, this will ensure there is always a location.
3. show error when calling getCurrentPosition fails

<!--- Provide a general summary of your changes in the Title above -->
##Issue Number:

## Description
<!--- Describe your changes in detail -->
##Do any new issues need to be created as a result of this PR"?


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
🚨Please review the [contribution guidelines](https://github.com/gwg-women/gwg-women-techmakers/wiki/Contribution-Guidelines) to this repository.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Created a new branch from 'dev' and PR is targeting the project's 'dev' branch.
- [ ] The issue can be closed.

 Provide a descriptive branch name and once the pull request is approved and merged to dev, the branch can be deleted.

💔Thank you!
